### PR TITLE
Remove reference to missing file image_types_uboot

### DIFF
--- a/recipes-core/images/openwrt-base-image.bb
+++ b/recipes-core/images/openwrt-base-image.bb
@@ -2,8 +2,6 @@ SUMMARY = "OpenWrt Base Image"
 
 LICENSE = "MIT"
 
-inherit core-image image_types_uboot
-
 CORE_IMAGE_BASE_INSTALL = '\
     packagegroup-core-boot-openwrt \
     kernel-modules \


### PR DESCRIPTION
This patch removes the `inherit core-image image_types_uboot` line from the openwrt-base-image recipe, since the file has been merged into oe-core.